### PR TITLE
fix: fix UnboundLocalError when calling BaseOptions.parse() more than once.

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -49,10 +49,9 @@ class BaseOptions():
 
     def gather_options(self):
         # initialize parser with basic options
-        if not self.initialized:
-            parser = argparse.ArgumentParser(
-                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-            parser = self.initialize(parser)
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser = self.initialize(parser)
 
         # get the basic options
         opt, _ = parser.parse_known_args()
@@ -94,7 +93,10 @@ class BaseOptions():
 
     def parse(self):
 
-        opt = self.gather_options()
+        if self.initialized:
+            return self.opt
+        else:
+            opt = self.gather_options()
         opt.isTrain = self.isTrain   # train or test
 
         # process opt.suffix


### PR DESCRIPTION
This fix returns the existing parsed options when BaseOptions.parse() is called more than once. In the parse() method, it is checked if the parser was already initialized before. If it was initialized before, then the existing parsed options are returned. Otherwise, the gather_options() method is called. This is done in line 96.

Before the fix, calling the method more than once would raise UnboundLocalError. The parser is initialized in the gather_options() method in line 52 inside the 'if' statement. However, the parser was never assigned to a member variable of the class. Thus, running the method a second time results into the 'if' statement evaluating to false and skipping over the parser initialization causing the error. The picture below shows an example of the error produced.

![UnboundLocalError](https://user-images.githubusercontent.com/22683922/171852746-f68ef062-5388-433e-b291-c01caca994b0.png)
